### PR TITLE
Add example mapping to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Plugin 'pbogut/fzf-mru.vim'
 - You can run `:FZFMru`, `:FZFMru [search-query]` or `:FZFMru [fzf-command-options]`.
 - For example: `:FZFMru --prompt "Sup? " -q "notmuch"` or `:FZFMru readme`
 - You can also map it to a shortcut with `map <leader>p :FZFMru<cr>`.
+- Or `fzf` with a preview: `nnoremap <silent> <leader>r :FZFMru --preview="bat --color always --style changes,header,grid {}" --preview-window="right:70%:noborder"<CR>`
 - Set `let g:fzf_mru_relative = 1` to only list files within current directory.
 - Set `let g:fzf_mru_no_sort = 1` to prevent `fzf` from sorting list while typing, it will keep list sorted by recency
 


### PR DESCRIPTION
Thanks for this great plugin. It didn't work out of the box for me, I was getting `bat` errors, probably due to existing `fzf`/`bat` configs in my environment. 

I've added an example mapping to the `README` that passes a `bat` command to the plugin. This should be helpful to new users of the plugin also having this issue, to throw into their `.vimrc` and get going with.