### PR TITLE
Add option to use a preview window when viewing MRU files.

### DIFF
--- a/autoload/fzf_mru/actions.vim
+++ b/autoload/fzf_mru/actions.vim
@@ -21,6 +21,14 @@ function! fzf_mru#actions#options() abort
   return options
 endfunction
 
+function! s:p(...)
+  let preview_window = get(g:, 'fzf_preview_window', '')
+    if len(preview_window)
+      return call('fzf#vim#with_preview', add(copy(a:000), preview_window))
+    endif
+  return {}
+endfunction
+
 function! fzf_mru#actions#mru(...) abort
   let params = fzf_mru#actions#params(get(a:, 001, ''))
   let options = extend(
@@ -33,5 +41,5 @@ function! fzf_mru#actions#mru(...) abort
 
   let extra = extend(copy(get(g:, 'fzf_layout', {'down': '~40%'})), options)
 
-  call fzf#run(fzf#wrap('name', extra, 0))
+  call fzf#run(fzf#wrap('name', extend(extra, s:p()), 0))
 endfunction


### PR DESCRIPTION
The s:p() function was stolen (and slightly modified) from FZF Vim (plugin/fzf.vim).