### PR TITLE
Integrate the `fzf_mru_exclude_current_file` option in the code and README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Plugin 'pbogut/fzf-mru.vim'
   This is useful if you have multiple copies of a repository on your computer
   that you switch between, and want to keep your MRU cache consistent between
   them.
-- Set `let g:fzf_mru_no_sort = 1` to prevent `fzf` from sorting list while typing, it will keep list sorted by recency
+- Set `let g:fzf_mru_no_sort = 1` to prevent `fzf` from sorting list while typing, it will keep list sorted by recency.
+- Set `let g:fzf_mru_exclude_current_file = 0` to include the current file in the list since it's excluded by default.
 
 ## Todo
 - [x] ~~Move CtrlP MRU functionality to the plugin itself~~

--- a/autoload/fzf_mru/mrufiles.vim
+++ b/autoload/fzf_mru/mrufiles.vim
@@ -148,8 +148,12 @@ fu! fzf_mru#mrufiles#cachefile()
 endf
 
 function! fzf_mru#mrufiles#source()
-  " remove current file from the list
-  return filter(copy(fzf_mru#mrufiles#list()), 'v:val != expand("%")')
+  let source = copy(fzf_mru#mrufiles#list())
+  if !empty(get(g:, 'fzf_mru_exclude_current_file', 1))
+    " remove current file from the list
+    let source = filter(source, 'v:val != expand("%")')
+  endif
+  return source
 endfunction
 
 fu! fzf_mru#mrufiles#init()


### PR DESCRIPTION
To close the https://github.com/pbogut/fzf-mru.vim/issues/21 and as per my comment in https://github.com/pbogut/fzf-mru.vim/issues/21#issuecomment-968052510

Tested to be working in these cases:
```vim
let g:fzf_mru_exclude_current_file = 1
let g:fzf_mru_exclude_current_file = 0
```
and when `fzf_mru_exclude_current_file` is not set/defined.

Thanks :)