### PR TITLE
Added :FZFMruWindows to switch to Most Recently Used Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Plugin 'pbogut/fzf-mru.vim'
 
 ## Basic Usage
 - You can run `:FZFMru`, `:FZFMru [search-query]` or `:FZFMru [fzf-command-options]`.
+- `:FZFMruWindows` for Recent Windows.
 - For example: `:FZFMru --prompt "Sup? " -q "notmuch"` or `:FZFMru readme`
 - You can also map it to a shortcut with `map <leader>p :FZFMru<cr>`.
 - Set `let g:fzf_mru_relative = 1` to only list files within current directory.

--- a/autoload/fzf_mru/actions.vim
+++ b/autoload/fzf_mru/actions.vim
@@ -35,3 +35,69 @@ function! fzf_mru#actions#mru(...) abort
 
   call fzf#run(fzf#wrap('name', extra, 0))
 endfunction
+
+if v:version >= 704
+  function! s:function(name)
+    return function(a:name)
+  endfunction
+else
+  function! s:function(name)
+    " By Ingo Karkat
+    return function(substitute(a:name, '^s:', matchstr(expand('<sfile>'), '<SNR>\d\+_\zefunction$'), ''))
+  endfunction
+endif
+
+function! s:jump(t, w)
+  execute a:t.'tabnext'
+  execute a:w.'wincmd w'
+endfunction
+
+function! s:format_win(tab, win, buf)
+  let modified = getbufvar(a:buf, '&modified')
+  let name = bufname(a:buf)
+  let name = empty(name) ? '[No Name]' : name
+  let active = tabpagewinnr(a:tab) == a:win
+  return (active? '> ' : '  ') . name . (modified? ' [+]' : '')
+endfunction
+
+function! s:windows_sink(line)
+  let list = matchlist(a:line, '^ *\([0-9]\+\) *\([0-9]\+\)')
+  call s:jump(list[1], list[2])
+endfunction
+
+function! fzf_mru#actions#windows()
+  let lines = []
+  let mru = fzf_mru#mrufiles#source()
+  let filteredBufs = []
+  let filteredBufsIndex = []
+  let tabs = []
+  let buffers = {}
+  for t in range(1, tabpagenr('$'))
+   let buffers[t] = tabpagebuflist(t)
+   for w in range(1, len(buffers[t]))
+     let index = index(mru, bufname(buffers[t][w-1]))
+     if index >= 0
+         call add(filteredBufs, mru[index])
+         call add(filteredBufsIndex, buffers[t][w-1])
+         call add(tabs, t)
+     endif
+   endfor
+  endfor
+  for item in range(1, len(mru))
+   let i = index(filteredBufs, mru[item-1])
+   if i < 0
+    continue
+   endif
+   let t = tabs[i]
+   let w = index(buffers[t], filteredBufsIndex[i]) + 1
+   call add(lines,
+     \ printf('%s %s  %s',
+         \ printf('%3d', tabs[i]),
+         \ printf('%3d', w),
+         \ s:format_win(tabs[i], w, filteredBufsIndex[i])))
+  endfor
+  call fzf#run(fzf#wrap("Recent Windows", {
+  \ 'source':  extend(['Tab Win    Name'], lines),
+  \ 'sink':    s:function('s:windows_sink'),
+  \ 'options': '+m --ansi --tiebreak=begin --header-lines=1'}))
+endfunction

--- a/autoload/fzf_mru/actions.vim
+++ b/autoload/fzf_mru/actions.vim
@@ -90,11 +90,14 @@ function! fzf_mru#actions#windows()
    endif
    let t = tabs[i]
    let w = index(buffers[t], filteredBufsIndex[i]) + 1
-   call add(lines,
-     \ printf('%s %s  %s',
-         \ printf('%3d', tabs[i]),
-         \ printf('%3d', w),
-         \ s:format_win(tabs[i], w, filteredBufsIndex[i])))
+   while w > 0
+    call add(lines,
+       \ printf('%s %s  %s',
+           \ printf('%3d', tabs[i]),
+           \ printf('%3d', w),
+           \ s:format_win(tabs[i], w, filteredBufsIndex[i])))
+    let w = index(buffers[t], filteredBufsIndex[i], w) + 1
+   endwhile
   endfor
   call fzf#run(fzf#wrap("Recent Windows", {
   \ 'source':  extend(['Tab Win    Name'], lines),

--- a/plugin/fzf_mru.vim
+++ b/plugin/fzf_mru.vim
@@ -17,3 +17,7 @@ endif
 if exists(':FZFFreshMru') != 2
   command! -nargs=* FZFFreshMru call fzf_mru#mrufiles#refresh() <bar> call fzf_mru#actions#mru(<q-args>)
 endif
+if exists(':FZFMruWindows') != 2
+  command! FZFMruWindows call fzf_mru#actions#windows()
+endif
+


### PR DESCRIPTION
Hi, I'v added a bridge between `FZF's` `:Windows` and `:FZFMru's` `:FZFMru`.
`:FZFMruWindows` can be used to switch between Most Recently Used Windows and Splits from all tabs.